### PR TITLE
Remove duplicate "AxonIQ Console" button

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -39,7 +39,7 @@
         {{/if}}
         <a class="navbar-item navbar-button" href="https://academy.axoniq.io" target="_blank">AxonIQ Academy</a>
         <a class="navbar-item navbar-button" href="https://discuss.axoniq.io" target="_blank">AxonIQ Discuss</a>
-        <a class="navbar-item navbar-button" href="https://console.axoniq.io" target="_blank">AxonIQ Console</a>
+        <a class="navbar-item navbar-button" href="https://axoniq.io/contact" target="_blank">Get in touch</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Remove the duplicate "AxonIQ Console" button and replace it with a "Contact" button.