### PR TITLE
Allow for pages without h1 header, 

### DIFF
--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -14,7 +14,10 @@
 {{else}}
     <article class="doc">
         {{#with page.title}}
-            <h1 class="page">{{{this}}}</h1>
+            {{#if (eq page.ingore-h1 'true')}}
+            {{else}}
+                <h1 class="page">{{{this}}}</h1>
+            {{/if}}
         {{/with}}
         {{#if (eq page.attributes.layout 'page-list')}}
             {{> page-list}}


### PR DESCRIPTION
as preparation for the AxonIQ Playbook tracking fix

See [https://github.com/AxonIQ/axoniq-playbook/pull/3](https://github.com/AxonIQ/axoniq-playbook/pull/3) for more details